### PR TITLE
tweak(fxmanifest): add ScaleformUI_Lua dependency

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,6 +4,7 @@ game 'gta5'
 author 'Gege'
 version '1.0.0'
 description 'Vehicle handling editor'
+dependency "ScaleformUI_Lua"
 
 client_scripts {
     "@ScaleformUI_Lua/ScaleformUI.lua",

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,11 @@ game 'gta5'
 author 'Gege'
 version '1.0.0'
 description 'Vehicle handling editor'
-dependency "ScaleformUI_Lua"
+
+dependencies {
+    'ScaleformUI_Assets',
+    'ScaleformUI_Lua'
+}
 
 client_scripts {
     "@ScaleformUI_Lua/ScaleformUI.lua",


### PR DESCRIPTION
without this dependency you will need to ensure ScaleformUI_Lua is started before starting HandlingEditor, adding it as a dependency both ensures it's started in the right order and that the user does not forget to install it.